### PR TITLE
feat:models option content sidebar for the Tatami

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -148,6 +148,29 @@ body {
     @apply bg-background text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
+
+  .hide-scrollbar {
+    -ms-overflow-style: none;  
+    scrollbar-width: none;     
+  }
+
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;          
+  }
+
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: rgba(234, 179, 8, 0.3);
+    border-radius: 4px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: rgba(234, 179, 8, 0.6);
+  }
 }
 
 @layer utilities {

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -21,11 +21,20 @@ import {
   Settings,
   Trash2,
   X,
+  Check,
+  Pencil,
 } from "lucide-react";
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Model, Property, PropertyItemProps } from "@/types/models";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 
+// Static menu items for the main sidebar
 const staticMenuItems = [
   { id: "models", label: "Make Models", icon: Database },
   { id: "templates", label: "Templates", icon: LayoutTemplate },
@@ -34,6 +43,7 @@ const staticMenuItems = [
   { id: "settings", label: "Settings", icon: Settings },
 ];
 
+// Dynamic content for each option
 const initialDynamicContent = {
   templates: [
     { id: "blank", label: "Blank Canvas" },
@@ -85,17 +95,28 @@ function PropertyItem({
         />
       </div>
       <div className="col-span-4">
-        <select
-          value={dataType}
-          onChange={(e) => onDataTypeChange(id, e.target.value)}
-          className="w-full h-8 rounded-md bg-background border border-yellow-500/20 text-foreground px-3"
-        >
-          {dataTypes.map((type) => (
-            <option key={type} value={type}>
-              {type}
-            </option>
-          ))}
-        </select>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button 
+              variant="outline" 
+              className="h-8 w-full justify-between bg-background border-yellow-500/20 text-foreground px-3 hover:bg-sidebar"
+            >
+              {dataType}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[8rem] bg-stone-800 border-yellow-500/20">
+            {dataTypes.map((type) => (
+              <DropdownMenuItem
+                key={type}
+                className="flex justify-between items-center text-foreground hover:bg-stone-700"
+                onClick={() => onDataTypeChange(id, type)}
+              >
+                {type}
+                {dataType === type && <Check className="h-4 w-4 text-yellow-500" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
       <div className="col-span-1 flex justify-center">
         <input
@@ -122,6 +143,8 @@ export function AppSidebar() {
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [dynamicContent, setDynamicContent] = useState(initialDynamicContent);
   const [models, setModels] = useState<Model[]>([]);
+  const [editingModelId, setEditingModelId] = useState<string | null>(null);
+  const [editModelName, setEditModelName] = useState<string>("");
 
   const toggleOption = (optionId: string) => {
     if (selectedOption === optionId) {
@@ -247,6 +270,12 @@ export function AppSidebar() {
         model.id === modelId ? { ...model, name } : model
       )
     );
+    setEditingModelId(null);
+  };
+  
+  const startEditingModelName = (modelId: string, currentName: string) => {
+    setEditingModelId(modelId);
+    setEditModelName(currentName);
   };
 
   const deleteModel = (modelId: string) => {
@@ -321,10 +350,45 @@ export function AppSidebar() {
                               )}
                             </button>
 
-                            <span className="font-medium text-foreground">{model.name}</span>
+                            {editingModelId === model.id ? (
+                              <div className="flex items-center gap-2">
+                                <Input
+                                  value={editModelName}
+                                  onChange={(e) => setEditModelName(e.target.value)}
+                                  className="h-8 bg-background border-yellow-500/20 text-foreground"
+                                  autoFocus
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                      updateModelName(model.id, editModelName);
+                                    } else if (e.key === 'Escape') {
+                                      setEditingModelId(null);
+                                    }
+                                  }}
+                                />
+                                <Button
+                                  size="sm"
+                                  onClick={() => updateModelName(model.id, editModelName)}
+                                  className="h-8 px-2 bg-yellow-500 hover:bg-yellow-600 text-black font-medium"
+                                >
+                                  Save
+                                </Button>
+                              </div>
+                            ) : (
+                              <span className="font-medium text-foreground">{model.name}</span>
+                            )}
                           </div>
 
                           <div className="flex items-center gap-2">
+                            {editingModelId !== model.id && (
+                              <button
+                                type="button"
+                                onClick={() => startEditingModelName(model.id, model.name)}
+                                className="text-muted-foreground hover:text-white"
+                              >
+                                <span className="sr-only">Edit</span>
+                                <Pencil className="h-4 w-4" />
+                              </button>
+                            )}
                             <button
                               type="button"
                               onClick={() => deleteModel(model.id)}

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Sidebar,
   SidebarContent,
@@ -17,17 +16,16 @@ import {
   ChevronDown,
   ChevronRight,
   Database,
-  Edit,
-  Layers,
   LayoutTemplate,
-  Plus,
+  Layers,
   Settings,
   Trash2,
   X,
 } from "lucide-react";
 import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Model, Property, PropertyItemProps } from "@/types/models";
 
-// Static menu items for the main sidebar
 const staticMenuItems = [
   { id: "models", label: "Make Models", icon: Database },
   { id: "templates", label: "Templates", icon: LayoutTemplate },
@@ -36,7 +34,6 @@ const staticMenuItems = [
   { id: "settings", label: "Settings", icon: Settings },
 ];
 
-// Dynamic content for each option
 const initialDynamicContent = {
   templates: [
     { id: "blank", label: "Blank Canvas" },
@@ -50,7 +47,6 @@ const initialDynamicContent = {
     { id: "text", label: "Text Elements" },
     { id: "icons", label: "Icons" },
   ],
-  models: [],
   layers: [
     { id: "layer1", label: "Layer 1" },
     { id: "layer2", label: "Layer 2" },
@@ -63,85 +59,96 @@ const initialDynamicContent = {
   ],
 };
 
-// Data type options for properties
 const dataTypes = ["String", "Number", "Boolean", "Date", "Object", "Array"];
+
+function PropertyItem({
+  id,
+  name,
+  dataType,
+  isKey,
+  onNameChange,
+  onDataTypeChange,
+  onKeyChange,
+  onDelete,
+}: PropertyItemProps) {
+  return (
+    <div className="grid grid-cols-12 gap-1 items-center bg-background rounded-md p-2 mb-2 bg-stone-700">
+      <div className="col-span-1 flex justify-center text-muted-foreground">
+        ≡
+      </div>
+      <div className="col-span-5">
+        <Input
+          value={name}
+          onChange={(e) => onNameChange(id, e.target.value)}
+          className="h-8 bg-background border-yellow-500/20 text-foreground"
+          placeholder="Name"
+        />
+      </div>
+      <div className="col-span-4">
+        <select
+          value={dataType}
+          onChange={(e) => onDataTypeChange(id, e.target.value)}
+          className="w-full h-8 rounded-md bg-background border border-yellow-500/20 text-foreground px-3"
+        >
+          {dataTypes.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="col-span-1 flex justify-center">
+        <input
+          type="checkbox"
+          checked={isKey}
+          onChange={(e) => onKeyChange(id, e.target.checked)}
+          className="h-4 w-4 rounded border-yellow-500/20 text-yellow-500 focus:ring-yellow-500"
+        />
+      </div>
+      <div className="col-span-1 flex justify-center">
+        <button
+          type="button"
+          onClick={() => onDelete(id)}
+          className="text-muted-foreground hover:text-red-500"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export function AppSidebar() {
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [dynamicContent, setDynamicContent] = useState(initialDynamicContent);
-  const [expandedModels, setExpandedModels] = useState<Record<string, boolean>>(
-    {},
-  );
-  const [models, setModels] = useState<
-    Array<{
-      id: string;
-      name: string;
-      properties: Array<{
-        id: string;
-        name: string;
-        dataType: string;
-        isKey: boolean;
-      }>;
-    }>
-  >([]);
-  const [editingModelId, setEditingModelId] = useState<string | null>(null);
-  const [newModelName, setNewModelName] = useState("");
+  const [models, setModels] = useState<Model[]>([]);
 
-  // Toggle the selected option
   const toggleOption = (optionId: string) => {
     if (selectedOption === optionId) {
-      // If clicking the same option, close it
       setSelectedOption(null);
     } else {
-      // Otherwise, select the new option
       setSelectedOption(optionId);
     }
   };
 
-  // Toggle model expansion
-  const toggleModelExpansion = (modelId: string) => {
-    setExpandedModels((prev) => ({
-      ...prev,
-      [modelId]: !prev[modelId],
-    }));
-  };
-
-  // Create a new model
-  const createModel = () => {
-    const newModelId = `model_${Date.now()}`;
-    const newModel = {
-      id: newModelId,
+  const addModel = () => {
+    const newModel: Model = {
+      id: `model_${Date.now()}`,
       name: `New Model ${models.length + 1}`,
-      properties: [],
+      expanded: true,
+      properties: [
+        {
+          id: `prop_${Date.now()}`,
+          name: "",
+          dataType: "String",
+          isKey: true
+        }
+      ]
     };
-
+    
     setModels([...models, newModel]);
-    setExpandedModels((prev) => ({
-      ...prev,
-      [newModelId]: true,
-    }));
-    setEditingModelId(newModelId);
-    setNewModelName(`New Model ${models.length + 1}`);
   };
 
-  // Delete a model
-  const deleteModel = (modelId: string) => {
-    setModels(models.filter((model) => model.id !== modelId));
-  };
-
-  // Save model name
-  const saveModelName = (modelId: string) => {
-    setModels(
-      models.map((model) =>
-        model.id === modelId
-          ? { ...model, name: newModelName || model.name }
-          : model,
-      ),
-    );
-    setEditingModelId(null);
-  };
-
-  // Add a property to a model
   const addProperty = (modelId: string) => {
     setModels(
       models.map((model) => {
@@ -152,58 +159,98 @@ export function AppSidebar() {
               ...model.properties,
               {
                 id: `prop_${Date.now()}`,
-                name: `Property ${model.properties.length + 1}`,
+                name: "",
                 dataType: "String",
-                isKey: model.properties.length === 0, // First property is key by default
+                isKey: model.properties.length === 0,
               },
             ],
           };
         }
         return model;
-      }),
+      })
     );
   };
 
-  // Delete a property
   const deleteProperty = (modelId: string, propertyId: string) => {
     setModels(
       models.map((model) => {
         if (model.id === modelId) {
           return {
             ...model,
-            properties: model.properties.filter(
-              (prop) => prop.id !== propertyId,
-            ),
+            properties: model.properties.filter((p) => p.id !== propertyId),
           };
         }
         return model;
-      }),
+      })
     );
   };
 
-  // Update property
-  const updateProperty = (
-    modelId: string,
-    propertyId: string,
-    field: string,
-    value: string | boolean,
-  ) => {
+  const updatePropertyName = (modelId: string, propertyId: string, name: string) => {
     setModels(
       models.map((model) => {
         if (model.id === modelId) {
           return {
             ...model,
-            properties: model.properties.map((prop) => {
-              if (prop.id === propertyId) {
-                return { ...prop, [field]: value };
-              }
-              return prop;
-            }),
+            properties: model.properties.map((p) => 
+              p.id === propertyId ? { ...p, name } : p
+            ),
           };
         }
         return model;
-      }),
+      })
     );
+  };
+
+  const updatePropertyDataType = (modelId: string, propertyId: string, dataType: string) => {
+    setModels(
+      models.map((model) => {
+        if (model.id === modelId) {
+          return {
+            ...model,
+            properties: model.properties.map((p) => 
+              p.id === propertyId ? { ...p, dataType } : p
+            ),
+          };
+        }
+        return model;
+      })
+    );
+  };
+
+  const updatePropertyKey = (modelId: string, propertyId: string, isKey: boolean) => {
+    setModels(
+      models.map((model) => {
+        if (model.id === modelId) {
+          return {
+            ...model,
+            properties: model.properties.map((p) => 
+              p.id === propertyId ? { ...p, isKey } : p
+            ),
+          };
+        }
+        return model;
+      })
+    );
+  };
+
+  const toggleModelExpansion = (modelId: string) => {
+    setModels(
+      models.map((model) => 
+        model.id === modelId ? { ...model, expanded: !model.expanded } : model
+      )
+    );
+  };
+
+  const updateModelName = (modelId: string, name: string) => {
+    setModels(
+      models.map((model) => 
+        model.id === modelId ? { ...model, name } : model
+      )
+    );
+  };
+
+  const deleteModel = (modelId: string) => {
+    setModels(models.filter((model) => model.id !== modelId));
   };
 
   return (
@@ -237,185 +284,97 @@ export function AppSidebar() {
       {selectedOption && (
         <Sidebar
           collapsible="none"
-          className="fixed left-[60px] top-16 h-[calc(100vh-64px)] z-[99] shadow-lg border-r border-yellow-500 w-[300px]"
+          className="fixed left-[60px] top-16 h-[calc(100vh-64px)] z-[99] shadow-lg border-r border-yellow-500 w-[350px] overflow-hidden"
         >
-          <SidebarContent>
-            <SidebarGroup>
-              <SidebarGroupLabel className="border-b border-yellow-500">
-                {
-                  staticMenuItems.find((item) => item.id === selectedOption)
-                    ?.label
-                }
+          <SidebarContent className="h-full flex flex-col overflow-hidden">
+            <SidebarGroup className="flex flex-col h-full overflow-hidden">
+              <SidebarGroupLabel className="border-b border-yellow-500 flex-shrink-0">
+                {staticMenuItems.find((item) => item.id === selectedOption)?.label}
               </SidebarGroupLabel>
 
               {selectedOption === "models" ? (
-                <div className="flex flex-col gap-2 p-2">
-                  <Button
-                    onClick={createModel}
-                    className="flex items-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-black font-medium"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Create Model
-                  </Button>
-
-                  <div className="mt-4 space-y-3">
+                <div className="flex flex-col h-full overflow-hidden">
+                  <div className="p-4 flex justify-end flex-shrink-0">
+                    <Button
+                      onClick={addModel}
+                      className="bg-black hover:bg-gray-900 text-white font-medium flex items-center gap-1"
+                    >
+                      <span className="text-lg">+</span> Add model
+                    </Button>
+                  </div>
+                  
+                  {/* Model list with custom scrollbar */}
+                  <div className="flex-1 overflow-y-auto custom-scrollbar px-2 pb-4">
                     {models.map((model) => (
-                      <div
-                        key={model.id}
-                        className="border border-yellow-500 rounded-md overflow-hidden"
-                      >
-                        <div className="flex items-center justify-between p-2 bg-yellow-500/10">
-                          <div className="flex items-center gap-2 flex-1">
+                      <div key={model.id} className="border border-yellow-500/20 rounded-md overflow-hidden mb-4">
+                        <div className="flex items-center justify-between p-3 bg-sidebar">
+                          <div className="flex items-center gap-2">
                             <button
                               type="button"
                               onClick={() => toggleModelExpansion(model.id)}
                               className="text-yellow-500 hover:text-yellow-600"
                             >
-                              {expandedModels[model.id] ? (
+                              {model.expanded ? (
                                 <ChevronDown className="h-5 w-5" />
                               ) : (
                                 <ChevronRight className="h-5 w-5" />
                               )}
                             </button>
 
-                            {editingModelId === model.id ? (
-                              <div className="flex items-center gap-2 flex-1">
-                                <Input
-                                  value={newModelName}
-                                  onChange={(e) =>
-                                    setNewModelName(e.target.value)
-                                  }
-                                  className="h-7 text-sm"
-                                  autoFocus
-                                />
-                                <Button
-                                  size="sm"
-                                  onClick={() => saveModelName(model.id)}
-                                  className="h-7 px-2 bg-yellow-500 hover:bg-yellow-600 text-black font-medium"
-                                >
-                                  Save
-                                </Button>
-                              </div>
-                            ) : (
-                              <div className="flex items-center gap-2 flex-1">
-                                <span className="font-medium">
-                                  {model.name}
-                                </span>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    setEditingModelId(model.id);
-                                    setNewModelName(model.name);
-                                  }}
-                                  className="text-yellow-500 hover:text-yellow-600"
-                                >
-                                  <Edit className="h-4 w-4" />
-                                </button>
-                              </div>
-                            )}
+                            <span className="font-medium text-foreground">{model.name}</span>
                           </div>
 
-                          <button
-                            type="button"
-                            onClick={() => deleteModel(model.id)}
-                            className="text-red-500 hover:text-red-600"
-                          >
-                            <Trash2 className="h-5 w-5" />
-                          </button>
+                          <div className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              onClick={() => deleteModel(model.id)}
+                              className="text-muted-foreground hover:text-red-500"
+                            >
+                              <Trash2 className="h-5 w-5" />
+                            </button>
+                          </div>
                         </div>
 
-                        {expandedModels[model.id] && (
-                          <div className="p-2 space-y-3">
-                            <div className="text-sm font-medium text-yellow-500 border-b border-yellow-500/30 pb-1">
-                              Properties
+                        {model.expanded && (
+                          <div className="p-3 bg-background">
+                            <h3 className="text-sm font-medium text-foreground mb-3">Properties</h3>
+                            
+                            <div className="grid grid-cols-12 gap-1 text-xs font-medium text-muted-foreground mb-2 px-2">
+                              <div className="col-span-1"></div>
+                              <div className="col-span-5">Name</div>
+                              <div className="col-span-4">Datatype</div>
+                              <div className="col-span-1 text-center">Key</div>
+                              <div className="col-span-1"></div>
                             </div>
 
-                            {model.properties.length > 0 && (
-                              <div className="space-y-2">
-                                <div className="grid grid-cols-12 gap-1 text-xs font-medium text-yellow-500/70">
-                                  <div className="col-span-4">Name</div>
-                                  <div className="col-span-4">Data Type</div>
-                                  <div className="col-span-3">Key</div>
-                                  <div className="col-span-1" />
-                                </div>
-
-                                {model.properties.map((property) => (
-                                  <div
-                                    key={property.id}
-                                    className="grid grid-cols-12 gap-1 items-center"
-                                  >
-                                    <div className="col-span-4">
-                                      <Input
-                                        value={property.name}
-                                        onChange={(e) =>
-                                          updateProperty(
-                                            model.id,
-                                            property.id,
-                                            "name",
-                                            e.target.value,
-                                          )
-                                        }
-                                        className="h-7 text-xs"
-                                      />
-                                    </div>
-                                    <div className="col-span-4">
-                                      <select
-                                        value={property.dataType}
-                                        onChange={(e) =>
-                                          updateProperty(
-                                            model.id,
-                                            property.id,
-                                            "dataType",
-                                            e.target.value,
-                                          )
-                                        }
-                                        className="w-full h-7 text-xs rounded-md border border-input bg-background px-3"
-                                      >
-                                        {dataTypes.map((type) => (
-                                          <option key={type} value={type}>
-                                            {type}
-                                          </option>
-                                        ))}
-                                      </select>
-                                    </div>
-                                    <div className="col-span-3 flex justify-center">
-                                      <input
-                                        type="checkbox"
-                                        checked={property.isKey}
-                                        onChange={(e) =>
-                                          updateProperty(
-                                            model.id,
-                                            property.id,
-                                            "isKey",
-                                            e.target.checked,
-                                          )
-                                        }
-                                        className="h-4 w-4 rounded border-gray-300 text-yellow-500 focus:ring-yellow-500"
-                                      />
-                                    </div>
-                                    <div className="col-span-1 flex justify-center">
-                                      <button
-                                        type="button"
-                                        onClick={() =>
-                                          deleteProperty(model.id, property.id)
-                                        }
-                                        className="text-red-500 hover:text-red-600"
-                                      >
-                                        <X className="h-4 w-4" />
-                                      </button>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
+                            {model.properties.map((property) => (
+                              <PropertyItem
+                                key={property.id}
+                                id={property.id}
+                                name={property.name}
+                                dataType={property.dataType}
+                                isKey={property.isKey}
+                                onNameChange={(propertyId, value) => 
+                                  updatePropertyName(model.id, propertyId, value)
+                                }
+                                onDataTypeChange={(propertyId, value) => 
+                                  updatePropertyDataType(model.id, propertyId, value)
+                                }
+                                onKeyChange={(propertyId, value) => 
+                                  updatePropertyKey(model.id, propertyId, value)
+                                }
+                                onDelete={(propertyId) => 
+                                  deleteProperty(model.id, propertyId)
+                                }
+                              />
+                            ))}
 
                             <Button
                               onClick={() => addProperty(model.id)}
-                              size="sm"
                               variant="outline"
-                              className="w-full mt-2 border-yellow-500 text-yellow-500 hover:bg-yellow-500/10 hover:text-black font-medium"
+                              className="w-full mt-2 border-yellow-500/20 text-muted-foreground hover:bg-sidebar hover:text-foreground"
                             >
-                              <Plus className="h-3 w-3 mr-1" /> Add Property
+                              <span className="mr-1">+</span> Add property
                             </Button>
                           </div>
                         )}

--- a/apps/frontend/components/models/ModelItem.tsx
+++ b/apps/frontend/components/models/ModelItem.tsx
@@ -1,0 +1,152 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { PropertyItem } from "./PropertyItem";
+
+interface Property {
+  id: string;
+  name: string;
+  dataType: string;
+  isKey: boolean;
+}
+
+interface ModelItemProps {
+  id: string;
+  name: string;
+  properties: Property[];
+  expanded: boolean;
+  onNameChange: (id: string, name: string) => void;
+  onExpandToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+  onPropertyAdd: (modelId: string) => void;
+  onPropertyDelete: (modelId: string, propertyId: string) => void;
+  onPropertyNameChange: (modelId: string, propertyId: string, name: string) => void;
+  onPropertyDataTypeChange: (modelId: string, propertyId: string, dataType: string) => void;
+  onPropertyKeyChange: (modelId: string, propertyId: string, isKey: boolean) => void;
+}
+
+export function ModelItem({
+  id,
+  name,
+  properties,
+  expanded,
+  onNameChange,
+  onExpandToggle,
+  onDelete,
+  onPropertyAdd,
+  onPropertyDelete,
+  onPropertyNameChange,
+  onPropertyDataTypeChange,
+  onPropertyKeyChange,
+}: ModelItemProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(name);
+
+  const handleSaveName = () => {
+    onNameChange(id, editName);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="border border-gray-700 rounded-md overflow-hidden mb-4">
+      <div className="flex items-center justify-between p-3 bg-gray-800">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onExpandToggle(id)}
+            className="text-yellow-500 hover:text-yellow-600"
+          >
+            {expanded ? (
+              <ChevronDown className="h-5 w-5" />
+            ) : (
+              <ChevronRight className="h-5 w-5" />
+            )}
+          </button>
+
+          {isEditing ? (
+            <div className="flex items-center gap-2">
+              <Input
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                className="h-8 bg-gray-700 border-none text-white"
+                autoFocus
+              />
+              <Button
+                size="sm"
+                onClick={handleSaveName}
+                className="h-8 px-2 bg-yellow-500 hover:bg-yellow-600 text-black font-medium"
+              >
+                Save
+              </Button>
+            </div>
+          ) : (
+            <span className="font-medium text-white">{name}</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => !isEditing && setIsEditing(true)}
+            className="text-gray-400 hover:text-white"
+          >
+            <span className="sr-only">Edit</span>
+            ✎
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(id)}
+            className="text-gray-400 hover:text-red-500"
+          >
+            <Trash2 className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="p-3 bg-gray-900">
+          <h3 className="text-sm font-medium text-white mb-3">Properties</h3>
+          
+          <div className="grid grid-cols-12 gap-1 text-xs font-medium text-gray-400 mb-2 px-2">
+            <div className="col-span-1"></div>
+            <div className="col-span-5">Name</div>
+            <div className="col-span-4">Datatype</div>
+            <div className="col-span-1 text-center">Key</div>
+            <div className="col-span-1"></div>
+          </div>
+
+          {properties.map((property) => (
+            <PropertyItem
+              key={property.id}
+              id={property.id}
+              name={property.name}
+              dataType={property.dataType}
+              isKey={property.isKey}
+              onNameChange={(propertyId, value) => 
+                onPropertyNameChange(id, propertyId, value)
+              }
+              onDataTypeChange={(propertyId, value) => 
+                onPropertyDataTypeChange(id, propertyId, value)
+              }
+              onKeyChange={(propertyId, value) => 
+                onPropertyKeyChange(id, propertyId, value)
+              }
+              onDelete={(propertyId) => 
+                onPropertyDelete(id, propertyId)
+              }
+            />
+          ))}
+
+          <Button
+            onClick={() => onPropertyAdd(id)}
+            variant="outline"
+            className="w-full mt-2 border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-white"
+          >
+            <span className="mr-1">+</span> Add property
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/models/PropertyItem.tsx
+++ b/apps/frontend/components/models/PropertyItem.tsx
@@ -1,0 +1,72 @@
+import { Input } from "@/components/ui/input";
+import { X } from "lucide-react";
+
+interface PropertyItemProps {
+  id: string;
+  name: string;
+  dataType: string;
+  isKey: boolean;
+  onNameChange: (id: string, value: string) => void;
+  onDataTypeChange: (id: string, value: string) => void;
+  onKeyChange: (id: string, value: boolean) => void;
+  onDelete: (id: string) => void;
+}
+
+const dataTypes = ["String", "Number", "Boolean", "Date", "Object", "Array"];
+
+export function PropertyItem({
+  id,
+  name,
+  dataType,
+  isKey,
+  onNameChange,
+  onDataTypeChange,
+  onKeyChange,
+  onDelete,
+}: PropertyItemProps) {
+  return (
+    <div className="grid grid-cols-12 gap-1 items-center bg-gray-800 rounded-md p-2 mb-2">
+      <div className="col-span-1 flex justify-center text-gray-400">
+        ≡
+      </div>
+      <div className="col-span-5">
+        <Input
+          value={name}
+          onChange={(e) => onNameChange(id, e.target.value)}
+          className="h-8 bg-gray-700 border-none text-white"
+          placeholder="Name"
+        />
+      </div>
+      <div className="col-span-4">
+        <select
+          value={dataType}
+          onChange={(e) => onDataTypeChange(id, e.target.value)}
+          className="w-full h-8 rounded-md bg-gray-700 border-none text-white px-3"
+        >
+          {dataTypes.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="col-span-1 flex justify-center">
+        <input
+          type="checkbox"
+          checked={isKey}
+          onChange={(e) => onKeyChange(id, e.target.checked)}
+          className="h-4 w-4 rounded border-gray-600 text-yellow-500 focus:ring-yellow-500"
+        />
+      </div>
+      <div className="col-span-1 flex justify-center">
+        <button
+          type="button"
+          onClick={() => onDelete(id)}
+          className="text-gray-400 hover:text-red-500"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/models/PropertyItem.tsx
+++ b/apps/frontend/components/models/PropertyItem.tsx
@@ -1,16 +1,13 @@
 import { Input } from "@/components/ui/input";
-import { X } from "lucide-react";
-
-interface PropertyItemProps {
-  id: string;
-  name: string;
-  dataType: string;
-  isKey: boolean;
-  onNameChange: (id: string, value: string) => void;
-  onDataTypeChange: (id: string, value: string) => void;
-  onKeyChange: (id: string, value: boolean) => void;
-  onDelete: (id: string) => void;
-}
+import { X, Check } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { PropertyItemProps } from "@/types/models";
 
 const dataTypes = ["String", "Number", "Boolean", "Date", "Object", "Array"];
 
@@ -25,44 +22,55 @@ export function PropertyItem({
   onDelete,
 }: PropertyItemProps) {
   return (
-    <div className="grid grid-cols-12 gap-1 items-center bg-gray-800 rounded-md p-2 mb-2">
-      <div className="col-span-1 flex justify-center text-gray-400">
+    <div className="grid grid-cols-12 gap-1 items-center bg-background rounded-md p-2 mb-2 bg-stone-700">
+      <div className="col-span-1 flex justify-center text-muted-foreground">
         ≡
       </div>
       <div className="col-span-5">
         <Input
           value={name}
           onChange={(e) => onNameChange(id, e.target.value)}
-          className="h-8 bg-gray-700 border-none text-white"
+          className="h-8 bg-background border-yellow-500/20 text-foreground"
           placeholder="Name"
         />
       </div>
       <div className="col-span-4">
-        <select
-          value={dataType}
-          onChange={(e) => onDataTypeChange(id, e.target.value)}
-          className="w-full h-8 rounded-md bg-gray-700 border-none text-white px-3"
-        >
-          {dataTypes.map((type) => (
-            <option key={type} value={type}>
-              {type}
-            </option>
-          ))}
-        </select>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button 
+              variant="outline" 
+              className="h-8 w-full justify-between bg-background border-yellow-500/20 text-foreground px-3 hover:bg-sidebar"
+            >
+              {dataType}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[8rem] bg-stone-800 border-yellow-500/20">
+            {dataTypes.map((type) => (
+              <DropdownMenuItem
+                key={type}
+                className="flex justify-between items-center text-foreground hover:bg-stone-700"
+                onClick={() => onDataTypeChange(id, type)}
+              >
+                {type}
+                {dataType === type && <Check className="h-4 w-4 text-yellow-500" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
       <div className="col-span-1 flex justify-center">
         <input
           type="checkbox"
           checked={isKey}
           onChange={(e) => onKeyChange(id, e.target.checked)}
-          className="h-4 w-4 rounded border-gray-600 text-yellow-500 focus:ring-yellow-500"
+          className="h-4 w-4 rounded border-yellow-500/20 text-yellow-500 focus:ring-yellow-500"
         />
       </div>
       <div className="col-span-1 flex justify-center">
         <button
           type="button"
           onClick={() => onDelete(id)}
-          className="text-gray-400 hover:text-red-500"
+          className="text-muted-foreground hover:text-red-500"
         >
           <X className="h-4 w-4" />
         </button>

--- a/apps/frontend/components/ui/custom-scroll.tsx
+++ b/apps/frontend/components/ui/custom-scroll.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface CustomScrollProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export function CustomScroll({ children, className, ...props }: CustomScrollProps) {
+  return (
+    <div
+      className={cn(
+        "scrollbar-thin scrollbar-thumb-yellow-500 scrollbar-track-transparent overflow-y-auto",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
+import scrollbar from 'tailwind-scrollbar';
 
 export default {
   darkMode: ["class"],
@@ -232,5 +233,5 @@ export default {
       },
     },
   },
-  plugins: [animate],
+  plugins: [animate, scrollbar],
 } satisfies Config;

--- a/apps/frontend/types/models.tsx
+++ b/apps/frontend/types/models.tsx
@@ -1,0 +1,24 @@
+export interface Property {
+    id: string;
+    name: string;
+    dataType: string;
+    isKey: boolean;
+  }
+  
+  export interface Model {
+    id: string;
+    name: string;
+    expanded: boolean;
+    properties: Property[];
+  }
+  
+  export interface PropertyItemProps {
+    id: string;
+    name: string;
+    dataType: string;
+    isKey: boolean;
+    onNameChange: (propertyId: string, value: string) => void;
+    onDataTypeChange: (propertyId: string, value: string) => void;
+    onKeyChange: (propertyId: string, value: boolean) => void;
+    onDelete: (propertyId: string) => void;
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "apps/*"
       ],
+      "dependencies": {
+        "tailwind-scrollbar": "^4.0.1"
+      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "lefthook": "^1.10.10",
@@ -59,10 +62,115 @@
         "typescript": "^5"
       }
     },
+    "apps/frontend/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "apps/frontend/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "apps/frontend/node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/frontend/node_modules/tailwindcss/node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -353,6 +461,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -370,6 +479,7 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -384,6 +494,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -391,6 +502,9 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -398,10 +512,16 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -543,6 +663,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -556,6 +677,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -565,6 +687,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -586,6 +709,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1516,6 +1640,12 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
@@ -1786,6 +1916,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1798,6 +1929,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1813,12 +1945,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1832,6 +1966,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2045,12 +2180,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2072,6 +2209,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2145,6 +2283,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2187,6 +2326,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2211,6 +2351,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2256,6 +2397,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2268,6 +2410,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -2283,6 +2426,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2297,6 +2441,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2311,6 +2456,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2448,12 +2594,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -2484,12 +2632,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -3099,6 +3249,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
       "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3119,6 +3270,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3174,9 +3326,10 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -3197,6 +3350,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3211,6 +3365,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3316,6 +3471,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -3336,6 +3492,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3348,6 +3505,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3357,6 +3515,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3488,6 +3647,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3597,6 +3757,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -3643,6 +3804,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -3689,6 +3851,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3712,6 +3875,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3738,6 +3902,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3761,6 +3926,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3917,6 +4083,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -3939,6 +4106,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -3954,6 +4122,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -4088,6 +4257,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4100,6 +4270,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -4136,6 +4307,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -4157,6 +4329,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4166,6 +4339,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4198,6 +4372,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4212,6 +4387,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -4322,6 +4498,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4331,6 +4508,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4340,6 +4518,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4507,6 +4686,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -4532,6 +4712,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4541,12 +4722,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -4567,6 +4750,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4579,6 +4763,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4588,6 +4773,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4605,6 +4791,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
       "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4633,6 +4820,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4650,6 +4838,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -4665,45 +4854,11 @@
         "postcss": "^8.4.21"
       }
     },
-    "node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4729,6 +4884,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4742,6 +4898,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -4750,6 +4907,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prism-react-renderer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/prop-types": {
@@ -4774,6 +4944,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4893,6 +5064,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4902,6 +5074,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4954,6 +5127,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -4990,6 +5164,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5000,6 +5175,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5168,6 +5344,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5180,6 +5357,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5257,6 +5435,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5295,6 +5474,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -5313,6 +5493,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5327,6 +5508,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5336,12 +5518,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5455,6 +5639,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5471,6 +5656,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5483,6 +5669,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5532,6 +5719,7 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -5565,6 +5753,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5581,76 +5770,33 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+    "node_modules/tailwind-scrollbar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.1.tgz",
+      "integrity": "sha512-j2ZfUI7p8xmSQdlqaCxEb4Mha8ErvWjDVyu2Ke4IstWprQ/6TmIz1GSLE62vsTlXwnMLYhuvbFbIFzaJGOGtMg==",
       "license": "MIT",
       "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
+        "prism-react-renderer": "^2.4.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "4.x"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.9.tgz",
+      "integrity": "sha512-12laZu+fv1ONDRoNR9ipTOpUD7RN9essRVkX36sjxuRUInpN7hIiHN4lBd/SIFjbISvnXzp8h/hXzmU8SQQYhw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/tapable": {
@@ -5665,6 +5811,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -5674,6 +5821,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -5725,6 +5873,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5748,6 +5897,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -5959,12 +6109,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6068,6 +6220,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -6086,6 +6239,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6103,6 +6257,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6112,12 +6267,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6132,6 +6289,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6144,6 +6302,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6156,6 +6315,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@biomejs/biome": "1.9.4",
     "lefthook": "^1.10.10",
     "turbo": "^2.4.0"
+  },
+  "dependencies": {
+    "tailwind-scrollbar": "^4.0.1"
   }
 }


### PR DESCRIPTION
# 📝 Pull Request Title

## 🛠️ Issue
- Closes #24 

## 📖 Description
This feature allows users to create and manage Dojo models through a dynamic sidebar interface. Users can create multiple models, add/delete properties, toggle model expansion, and define property types in a user-friendly interface.

## ✅ Changes made
- Created a new implementation for the models sidebar option
- Added functionality to create and delete models
- Implemented property management (add, delete, set key property)
- Added support for various data types (String, Number, Boolean, Date, Object, Array)
- Implemented expand/collapse functionality for models
- Created custom scrollbar styles for better UX when many models are present
- Added type definitions for models and properties in types/models.ts
- Adjusted sidebar width for better visibility of content
-  Optimized layout to work with any number of models

## 🖼️ Media (screenshots/videos)

https://github.com/user-attachments/assets/4d39baf7-1950-476e-8fe7-afff9771473e


## 📜 Additional Notes
The implementation follows the design specified in the task and adapts it to the dark theme colors of the project. The custom scrollbar improves user experience when working with multiple models.