### PR TITLE
feat: Added the component to display the tooltip on Datatype and Traits options.

### DIFF
--- a/apps/frontend/app/app/tatami_sidebar/TraitsDropdown.tsx
+++ b/apps/frontend/app/app/tatami_sidebar/TraitsDropdown.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState, useRef, useEffect } from 'react'; 
 import { ChevronDown, Check } from 'lucide-react';
+import { TypeInfoTooltip } from '@/components/ui/type-info-tooltip';
 
 interface TraitsDropdownProps {
   modelId: string;
@@ -82,14 +83,15 @@ const TraitsDropdown: React.FC<TraitsDropdownProps> = ({ modelId, onTraitToggle,
             {availableTraits.map((trait) => (
               <div 
                 key={trait.id}
-                className="flex items-center justify-between px-4 py-1.5 hover:bg-neutral-100 cursor-pointer"
+                className="flex items-center px-4 py-1.5 hover:bg-neutral-100 cursor-pointer"
                 onClick={() => toggleTrait(trait.id)}
               >
-                <div className="flex items-center">
-                  <span className="text-sm">{trait.name}</span>
-                </div>
-                <div className="w-4 h-4 flex items-center justify-center border border-neutral rounded bg-foreground text-background">
-                  {selectedTraits.includes(trait.name) && <Check className="h-3 w-3" />}
+                <span className="text-sm flex-grow">{trait.name}</span>
+                <div className="flex items-center gap-2">
+                  <div className="w-4 h-4 flex items-center justify-center border border-neutral rounded bg-foreground text-background">
+                    {selectedTraits.includes(trait.name) && <Check className="h-3 w-3" />}
+                  </div>
+                  <TypeInfoTooltip value={trait.name} className="h-4 w-4" />
                 </div>
               </div>
             ))}

--- a/apps/frontend/app/app/tatami_sidebar/model-sidebar-section.tsx
+++ b/apps/frontend/app/app/tatami_sidebar/model-sidebar-section.tsx
@@ -24,7 +24,7 @@ function ModelSidebarSection({ modelSection }: Props) {
 
       <div className="flex-1 overflow-y-auto custom-scrollbar px-2 pb-4 overflow-x-visible">
         {modelSection.models.map((model) => (
-          <div key={model.id} className="border border-neutral bg-neutral rounded-md overflow-hidden mb-4">
+          <div key={model.id} className="border border-neutral bg-neutral rounded-md mb-4">
             <div className="flex items-center justify-between p-3 bg-neutral text-foreground flex-wrap">
               <div className="flex items-center gap-2 flex-1 flex-wrap">
                 <button type="button" onClick={() => modelSection.toggleModelExpansion(model.id)}>

--- a/apps/frontend/components/ui/select.tsx
+++ b/apps/frontend/components/ui/select.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+import { TypeInfoTooltip } from '@/components/ui/type-info-tooltip';
+
 const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
@@ -123,11 +125,19 @@ const SelectItem = React.forwardRef<
     )}
     {...props}
   >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute right-8 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
+
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <TypeInfoTooltip
+        value={props.value}
+        className="h-4 w-4"
+      />
+    </span>
+
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ));

--- a/apps/frontend/components/ui/type-info-tooltip.tsx
+++ b/apps/frontend/components/ui/type-info-tooltip.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+// Data type information with descriptions, ranges, and examples
+export const DATA_TYPES = {
+  u8: {
+    description: 'Unsigned 8-bit integer',
+    range: '0 to 255',
+    example: 'let level: u8 = 100;',
+  },
+  u16: {
+    description: 'Unsigned 16-bit integer',
+    range: '0 to 65,535',
+    example: 'let small_id: u16 = 3000;',
+  },
+  u32: {
+    description: 'Unsigned 32-bit integer',
+    range: '0 to 4,294,967,295',
+    example: 'let item_id: u32 = 1_000_000;',
+  },
+  u64: {
+    description: 'Unsigned 64-bit integer',
+    range: '0 to 1.84e19',
+    example: 'let eth_gwei: u64 = 1e9;',
+  },
+  u128: {
+    description: 'Unsigned 128-bit integer',
+    range: '0 to 3.4e38',
+    example: 'let total_supply: u128 = 1e24;',
+  },
+  u256: {
+    description: 'Unsigned 256-bit integer',
+    range: '0 to 1.15e77',
+    example: 'let market_cap: u256 = 1e60;',
+  },
+  ByteArray: {
+    description: 'Fixed-size byte array (hex/raw bytes)',
+    range: 'Compile-time defined length',
+    example: 'let hash = b"a1b2c3";',
+  },
+  String: {
+    description: 'UTF-8 encoded string',
+    range: 'Variable length',
+    example: 'let name = "Player1";',
+  },
+  Bool: {
+    description: 'Boolean value',
+    range: 'true/false',
+    example: 'let is_active = true;',
+  },
+  ContractAddress: {
+    description: 'Typed contract address (wraps felt)',
+    range: '251 bits',
+    example: 'let contract = 0x123...;',
+  },
+};
+
+// Trait information with descriptions and use cases
+export const TRAITS = {
+  Drop: {
+    description: 'Hint to the compiler that a type can be safely destroyed when no longer used',
+    useCase: 'Automatically cleanup temporary variables',
+  },
+  Serde: {
+    description: 'Provides serialization/deserialization trait implementations',
+    useCase: 'Converting structs to byte arrays for storage or transmission',
+  },
+  IntrospectPacked: {
+    description: 'Attempts to pack multiple attributes into a single felt252',
+    useCase: 'Optimizing storage space for small data structures',
+  },
+  Debug: {
+    description: 'Enables printing of type instances for debugging',
+    useCase: 'Inspecting variable values during development (println!("{:?}", my_var))',
+  },
+  Copy: {
+    description: 'Allows types to be duplicated by copying felts (no new memory allocation)',
+    useCase: 'Efficiently cloning simple types like integers or small structs',
+  },
+};
+
+export interface TypeInfoTooltipProps {
+  value: string;
+  className?: string;
+}
+
+export function TypeInfoTooltip({ value, className }: TypeInfoTooltipProps) {
+  // Determine if the value is a data type or trait
+  const isDataType = value in DATA_TYPES;
+  const isTrait = value in TRAITS;
+  
+  // Get the appropriate data based on the value
+  const data = isDataType 
+    ? DATA_TYPES[value as keyof typeof DATA_TYPES]
+    : TRAITS[value as keyof typeof TRAITS];
+  
+  if (!data) {
+    return null; // Don't render if we don't have info for this value
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger className={className}>
+        <Info className="w-4 h-4" style={{ color: "#f7c618" }} />
+      </TooltipTrigger>
+      <TooltipContent>
+        {isDataType ? (
+          <DataTypeTooltipContent data={data as typeof DATA_TYPES[keyof typeof DATA_TYPES]} />
+        ) : (
+          <TraitTooltipContent data={data as typeof TRAITS[keyof typeof TRAITS]} />
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// Component for data type tooltip content
+interface DataTypeTooltipContentProps {
+  data: {
+    description: string;
+    range: string;
+    example: string;
+  };
+}
+
+function DataTypeTooltipContent({ data }: DataTypeTooltipContentProps) {
+  return (
+    <div className="absolute w-[300px] p-4 rounded-xl bg-background text-white shadow-lg text-sm space-y-4 border border-[#2c2c2c] z-50 ml-8">
+      <div className="space-y-3">
+        <div>
+          <span className="font-semibold text-gray-300">Description</span>
+          <p className="mt-1">{data.description}</p>
+        </div>
+        <div>
+          <span className="font-semibold text-gray-300">Size/Range</span>
+          <p className="mt-1">{data.range}</p>
+        </div>
+        <div>
+          <span className="font-semibold text-gray-300">Example</span>
+          <div className="mt-1">
+            <code className="px-2 py-1 rounded-md bg-[#f7c618] text-background font-mono block overflow-x-auto">
+              {data.example}
+            </code>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Component for trait tooltip content
+interface TraitTooltipContentProps {
+  data: {
+    description: string;
+    useCase: string;
+  };
+}
+
+function TraitTooltipContent({ data }: TraitTooltipContentProps) {
+  return (
+    <div className="absolute left-16 w-[300px] p-4 rounded-xl bg-background text-white shadow-lg text-sm space-y-4 border border-[#2c2c2c] z-100 ml-8">
+      <div className="space-y-3">
+        <div>
+          <span className="font-semibold text-gray-300">Description</span>
+          <p className="mt-1">{data.description}</p>
+        </div>
+        <div>
+          <span className="font-semibold text-gray-300">Use Case Example</span>
+          <p className="mt-1">{data.useCase}</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 📝 Pull Request Title
Added the component to display the tooltip on Datatype and Traits options.

## 🛠️ Issue
- Closes #85

## 📖 Description
- Added a new Component called Type-Info-Tooltip into components > ui.
- Added a validation to show the tooltip only when we have data and not in all selects.
- Added new logic to implement type-info-tooltip into select component.
- Added new logic to implement type-info-tooltip into TraitDropdown component.

## ✅ Changes made
- The type-info-tooltip component was created. In this component we have map all the required data to build the tooltip Content with the correct information. 
- A validation to show the correct information in the datatype/trait was created.
- A validation to show or hide the component was created.
- Included smooth transitions for showing/hiding the tooltip.
- The type-info-tooltip component was implemented on select component with the required styles to show it correctly.
- The type-info-tooltip component was implemented on traitsDropdown component with the required styles to show it correctly.

## 🖼️ Media (screenshots/videos)
https://github.com/user-attachments/assets/899c57d5-d44f-461a-a9a3-a898d665efb4

## 📜 Additional Notes
- The tooltip is triggered when we hover the "i" icon.
- The component is fully reusable and can be easily integrated into other parts of the application.
- The tooltip includes configurable parameters for send the correct data into the component.
