### PR TITLE
refactor: make metrics dynamic per endpoint

### DIFF
--- a/apps/frontend/app/app/metrics/graphiql-interface.tsx
+++ b/apps/frontend/app/app/metrics/graphiql-interface.tsx
@@ -17,7 +17,7 @@ export function GraphiQLInterface({ fetcher }: GraphiQLInterfaceProps) {
 
   return (
     <div className="min-h-[600px] xl:h-full w-full">
-      <GraphiQL fetcher={fetcher} />
+      <GraphiQL fetcher={fetcher} defaultQuery="" />
     </div>
   )
 }

--- a/apps/frontend/app/app/metrics/graphql-endpoint-form.tsx
+++ b/apps/frontend/app/app/metrics/graphql-endpoint-form.tsx
@@ -25,18 +25,18 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>
 
 interface GraphQLEndpointFormProps {
-  connect: (endpoint: string) => void
+  onSetEndpoint: (endpoint: string) => void
   onLoadMetrics: () => void
 }
 
-export function GraphQLEndpointForm({ connect, onLoadMetrics }: GraphQLEndpointFormProps) {
+export function GraphQLEndpointForm({ onSetEndpoint, onLoadMetrics }: GraphQLEndpointFormProps) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: { endpoint: '' },
   })
 
   const onSubmit = (data: FormValues) => {
-    connect(data.endpoint)
+    onSetEndpoint(data.endpoint)
   }
 
   return (

--- a/apps/frontend/app/app/metrics/mock-metrics.tsx
+++ b/apps/frontend/app/app/metrics/mock-metrics.tsx
@@ -1,0 +1,37 @@
+export const mockModelsResponse = {
+  data: {
+    models: {
+      edges: [
+        { node: { name: "BeastStatus", namespace: "tamagotchi" } },
+        { node: { name: "Beast", namespace: "tamagotchi" } },
+        { node: { name: "Food", namespace: "tamagotchi" } },
+        { node: { name: "Player", namespace: "tamagotchi" } },
+      ],
+    },
+    tamagotchiPlayerModels: { totalCount: 88 },
+    tamagotchiBeastModels: { totalCount: 112 },
+    tamagotchiFoodModels: { totalCount: 1168 },
+    tamagotchiBeastStatusModels: { totalCount: 112 },
+  },
+}
+
+export const mockTransactionsResponse = {
+  data: {
+    transactions: {
+      edges: [
+        { node: { id: "2023-01-xyz", calldata: new Array(320).fill("0x0") } },
+        { node: { id: "2023-02-xyz", calldata: new Array(350).fill("0x0") } },
+        { node: { id: "2023-03-xyz", calldata: new Array(410).fill("0x0") } },
+        { node: { id: "2023-04-xyz", calldata: new Array(490).fill("0x0") } },
+        { node: { id: "2023-05-xyz", calldata: new Array(550).fill("0x0") } },
+        { node: { id: "2023-06-xyz", calldata: new Array(620).fill("0x0") } },
+        { node: { id: "2023-07-xyz", calldata: new Array(690).fill("0x0") } },
+        { node: { id: "2023-08-xyz", calldata: new Array(820).fill("0x0") } },
+        { node: { id: "2023-09-xyz", calldata: new Array(635).fill("0x0") } },
+        { node: { id: "2023-10-xyz", calldata: new Array(580).fill("0x0") } },
+        { node: { id: "2023-11-xyz", calldata: new Array(510).fill("0x0") } },
+        { node: { id: "2023-12-xyz", calldata: new Array(635).fill("0x0") } },
+      ],
+    },
+  },
+}

--- a/apps/frontend/app/app/metrics/page.tsx
+++ b/apps/frontend/app/app/metrics/page.tsx
@@ -17,6 +17,7 @@ export default function MetricsPage() {
   const [modelsData, setModelsData] = useState<ModelDataItem[] | null>(null)
   const [transactionsData, setTransactionsData] = useState<TransactionDataPoint[] | null>(null)
   const [hasFetched, setHasFetched] = useState(false)
+  const [endpoint, setEndpoint] = useState<string>("")
 
   const { toast } = useToast()
 
@@ -28,8 +29,22 @@ export default function MetricsPage() {
     })
   })
 
+  const handleSetEndpoint = (url: string) => {
+    setEndpoint(url)
+    connect(url)
+  }
+
   const onLoadMetrics = async () => {
-    const client = createApolloClient("https://api.cartridge.gg/x/hhbbb/torii/graphql")
+    if (!endpoint) {
+      toast({
+        title: "Missing Endpoint",
+        description: "Please provide a valid API URL before loading metrics.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    const client = createApolloClient(endpoint)
 
     try {
       const results = await Promise.all([
@@ -68,7 +83,7 @@ export default function MetricsPage() {
 
   return (
     <main className="space-y-6 px-4">
-      <GraphQLEndpointForm connect={connect} onLoadMetrics={onLoadMetrics} />
+      <GraphQLEndpointForm onSetEndpoint={handleSetEndpoint} onLoadMetrics={onLoadMetrics} />
 
       <div className="grid grid-cols-1 xl:grid-cols-3 pb-4 xl:pb-0 gap-6">
         <div

--- a/apps/frontend/app/app/metrics/page.tsx
+++ b/apps/frontend/app/app/metrics/page.tsx
@@ -30,6 +30,12 @@ export default function MetricsPage() {
   })
 
   const handleSetEndpoint = (url: string) => {
+    if (url !== endpoint) {
+      setHasFetched(false)
+      setModelsData(null)
+      setTransactionsData(null)
+    }
+
     setEndpoint(url)
     connect(url)
   }

--- a/apps/frontend/app/app/metrics/transactions-chart.tsx
+++ b/apps/frontend/app/app/metrics/transactions-chart.tsx
@@ -6,22 +6,6 @@ import { TrendingDown, TrendingUp } from "lucide-react"
 import type { CustomTooltipProps } from "../../../types/charts"
 import type { TransactionDataPoint } from "@/types/charts"
 
-// Simulated data for the transactions chart
-// const transactionData: TransactionDataPoint[] = [
-//   { date: "2023-01", value: 320 },
-//   { date: "2023-02", value: 350 },
-//   { date: "2023-03", value: 410 },
-//   { date: "2023-04", value: 490 },
-//   { date: "2023-05", value: 550 },
-//   { date: "2023-06", value: 620 },
-//   { date: "2023-07", value: 690 },
-//   { date: "2023-08", value: 820 },
-//   { date: "2023-09", value: 635 },
-//   { date: "2023-10", value: 580 },
-//   { date: "2023-11", value: 510 },
-//   { date: "2023-12", value: 635 },
-// ]
-
 // Custom tooltip
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (active && payload && payload.length) {

--- a/apps/frontend/hooks/use-graphql-connection.ts
+++ b/apps/frontend/hooks/use-graphql-connection.ts
@@ -30,6 +30,13 @@ export function useGraphQLConnection(onError?: (msg: string) => void): UseGraphQ
    */
   const connect = async (endpoint: string) => {
     try {
+      // Clear GraphiQL tab/session state from localStorage
+      Object.keys(localStorage).forEach((key) => {
+        if (key.startsWith('graphiql:')) {
+          localStorage.removeItem(key)
+        }
+      })
+
       // Check if the endpoint responds
       const response = await fetch(endpoint, {
         method: 'POST',

--- a/apps/frontend/lib/graphql/metrics.queries.ts
+++ b/apps/frontend/lib/graphql/metrics.queries.ts
@@ -102,23 +102,9 @@ export const GET_ALL_MODELS_DATA = gql`
       edges {
         node {
           name
+          namespace
         }
       }
-    }
-    tamagotchiPlayerModels {
-      totalCount
-    }
-    tamagotchiBeastModels {
-      totalCount
-    }
-    tamagotchiFoodModels {
-      totalCount
-    }
-    tamagotchiBeastStatusModels {
-      totalCount
-    }
-    entities {
-      totalCount
     }
   }
 `

--- a/apps/frontend/types/charts.ts
+++ b/apps/frontend/types/charts.ts
@@ -6,6 +6,11 @@ import type {
 
 export type CustomTooltipProps = TooltipProps<ValueType, NameType>;
 
+export interface ModelInfo {
+  name: string
+  namespace: string
+}
+
 export interface ModelDataItem {
   name: string
   value: number


### PR DESCRIPTION
# 📝 Make metrics dynamic per endpoint

## 🛠️ Issue
- Closes #92 

## 📖 Description

Now the API URL is taken dynamically from the input field, and all models returned by the GraphQL schema are queried dynamically using the `namespace + name + Models` pattern.

## ✅ Changes made

- Replaced hardcoded API URL with input field value.
- Dynamically queries each model's `totalCount` based on the models list.
- Resets GraphiQL editor state on endpoint connect.
- Hides charts on endpoint change until "Metrics" is clicked again.

## 🖼️ Media (screenshots/videos)

https://github.com/user-attachments/assets/e708257f-5e66-47d5-850c-b16b71a8636d


## 📜 Additional Notes
- 
