### PR TITLE
Created  new user event

### DIFF
--- a/apps/backend/src/models/user.cairo
+++ b/apps/backend/src/models/user.cairo
@@ -2,6 +2,17 @@
 use starknet::ContractAddress;
 use core::num::traits::zero::Zero;
 
+
+// Event definition for user creation
+#[derive(Copy, Drop, Serde)]
+#[dojo::event]
+pub struct UserCreated {
+    #[key]
+    pub user_id: ContractAddress,
+    pub address: ContractAddress,
+    pub timestamp: u64,
+}
+
 // Model
 #[derive(Copy, Drop, Serde, IntrospectPacked, Debug)]
 #[dojo::model]

--- a/apps/backend/src/systems/users.cairo
+++ b/apps/backend/src/systems/users.cairo
@@ -3,7 +3,7 @@ use starknet::ContractAddress;
 use dojo::world::IWorldDispatcher;
 use dojo::world::WorldDispatcherTrait;
 use dojo::model::ModelTrait;
-use crate::models::user::{User, UserTrait};
+use crate::models::user::{User, UserTrait, UserCreated};
 
 #[dojo::system]
 pub struct Users;
@@ -19,6 +19,13 @@ impl Users {
     ) {
         let user = User::new(address, creation_timestamp, 0, creation_timestamp, true);
         world.set::<User>(user);
+        
+        // Emit UserCreated event
+        world.emit_event(@UserCreated {
+            user_id: address,
+            address: address,
+            timestamp: creation_timestamp,
+        });
     }
 
     #[dojo::action]


### PR DESCRIPTION
# 📝 Created new user event

## 🛠️ Issue
- Closes #132 

## 📖 Description
- Defined a new UserCreated event according to Dojo event standards.
- Event includes user_id, address, and timestamp fields.

## ✅ Changes made
- Added the UserCreated event definition.

## 🖼️ Media (screenshots/videos)
-

## 📜 Additional Notes
- Event integration and emission will be handled in future updates.
